### PR TITLE
chore: add license and description to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "nile-library"
 version = "0.0.0-git"
 edition = "2021"
+license = "MIT"
+description = "Library supporting nile"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
This is required before a package can be published on crates.io